### PR TITLE
Allow specifying Atlantis command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 | certificate\_arn | ARN of certificate issued by AWS ACM. If empty, a new ACM certificate will be created and validated using Route53 DNS | string | `""` | no |
 | cidr | The CIDR block for the VPC which will be created if `vpc_id` is not specified | string | `""` | no |
 | cloudwatch\_log\_retention\_in\_days | Retention period of Atlantis CloudWatch logs | number | `"7"` | no |
+| command | Command to invoke when running the Atlantis container (as a list of command line items) | list(string) | `["server"]` | no |
 | container\_memory\_reservation | The amount of memory (in MiB) to reserve for the container | number | `"128"` | no |
 | create\_route53\_record | Whether to create Route53 record for Atlantis | bool | `"true"` | no |
 | custom\_container\_definitions | A list of valid container definitions provided as a single valid JSON document. By default, the standard container definition is used. | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -414,6 +414,8 @@ module "container_definition_github_gitlab" {
   container_memory             = var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
 
+  command = var.command
+
   port_mappings = [
     {
       containerPort = var.atlantis_port
@@ -450,6 +452,8 @@ module "container_definition_bitbucket" {
   container_cpu                = var.ecs_task_cpu
   container_memory             = var.ecs_task_memory
   container_memory_reservation = var.container_memory_reservation
+
+  command = var.command
 
   port_mappings = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -301,3 +301,9 @@ variable "aws_ssm_path" {
   type        = string
   default     = "aws"
 }
+
+variable "atlantis_command_line" {
+  description = "Command to invoke when running the Atlantis container (as a list of command line items)"
+  type        = list(string)
+  default     = ["server"]
+}


### PR DESCRIPTION
This PR pulls in the work by @sftim upstream to our own fork. It enables the CMD run by atlantis to be specified in terraform.